### PR TITLE
Allow lts alias for automated installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ curl -L http://git.io/n-install | bash
 curl -L http://git.io/n-install | bash -s -- -y
 ```
 
-* Automated installation to the default location, with subsequent installation of the latest stable Node.js version, as well as the latest 0.10.x release:
+* Automated installation to the default location, with subsequent installation of the latest stable Node.js version, the latest lts version, and the latest 0.10.x release:
 
 ```shell
-curl -L http://git.io/n-install | bash -s -- -y stable stable 0.10
+curl -L http://git.io/n-install | bash -s -- -y stable lts 0.10
 ```
 
 * Automated installation to custom location `~/util/n`, with subsequent installation of the latest stable Node.js version:

--- a/bin/n-install
+++ b/bin/n-install
@@ -563,7 +563,7 @@ else # operands specified: interpret them as Node.js versions to install
           # we expect that to be the only operand, since an explicit list
           # of operands always overrides the default, but we don't enforce this.
         ;;
-      stable|latest|io:stable|io:latest) # symbolic names for latest stable / unstable versions
+      lts|stable|latest|io:stable|io:latest) # symbolic names for latest stable / unstable versions
         versionsToInstall+=( "$ver" )
         ;;
       *) # must be a version number in the form <major>.<minor>[.<patch>]


### PR DESCRIPTION
n now supports the `lts` alias, see:
https://github.com/tj/n/pull/322

`curl -L http://git.io/n-install | bash -s -- -y lts` fails
because it is not in `n-install` whitelist, this commits adds it.