### PR TITLE
Repalce all git.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Additionally, installs scripts `n-update` for later on-demand updating of `n`, a
 The simplest case is **installation of `n` with confirmation prompt**, with subsequent **installation of the latest LTS Node.js version**:
 
 ```shell
-curl -L https://git.io/n-install | bash
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash
 ```
 
 This is by far **the simplest way to get started with both `n` and Node.js** - even if you're looking to install only the latest LTS (long-term support) Node.js version, with no (immediate) plans to install _multiple_ versions.
@@ -46,7 +46,7 @@ This is by far **the simplest way to get started with both `n` and Node.js** - e
     * Directory `$N_PREFIX/bin` is appended to the `$PATH`, unless already present.
     * For other shells, these modification must be performed manually; instructions are provided during installation.
     * NoteL You can also suppress modification with the `-n` option.
-    * **Note**: If you want to override what shell's initialization file is updated, set the `SHELL` environment variable to that shell's file name (e.g., `fish`) before calling the installation command; e.g., from a POSIX-compatible shell: `curl -L https://git.io/n-install | SHELL=fish bash`; similarly, on uninstallation you'll have to use `SHELL=fish n-uninstall`
+    * **Note**: If you want to override what shell's initialization file is updated, set the `SHELL` environment variable to that shell's file name (e.g., `fish`) before calling the installation command; e.g., from a POSIX-compatible shell: `curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | SHELL=fish bash`; similarly, on uninstallation you'll have to use `SHELL=fish n-uninstall`
 * By default, the latest LTS Node.js version is installed; you can suppress that or even specify multiple Node.js versions to install.
 * Note that any preexisting `n`, Node.js installation must be removed before using this installation method.
 * All installation prerequisites are met by default on macOS and some Linux distros; notably, `git` and `curl` must be present - see [Installing n](#installing-n) for details.
@@ -65,33 +65,33 @@ Note: The examples use only `curl` for brevity; to run a given command with `wge
 * Installation with confirmation prompt to default location `$HOME/n` and installation of the latest LTS Node.js version:
 
 ```shell
-curl -L https://git.io/n-install | bash
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash
 ```
 
 * Automated installation to default location `$HOME/n` and installation of the latest LTS Node.js version:
 
 ```shell
-curl -L https://git.io/n-install | bash -s -- -y
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash -s -- -y
 ```
 
 * Automated, _quiet_ installation to default location `$HOME/n` and installation of the latest LTS Node.js version; _no status information_
 is displayed:
 
 ```shell
-curl -sL https://git.io/n-install | bash -s -- -q
+curl -sL https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash -s -- -q
 ```
 
 * Automated installation to the default location, with subsequent installation of the latest LTS
   (Long Term Support) version, and the latest 0.10.x release:
 
 ```shell
-curl -L https://git.io/n-install | bash -s -- -y lts 0.10
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash -s -- -y lts 0.10
 ```
 
 * Automated installation to custom location `~/util/n`, with subsequent installation of the latest LTS Node.js version:
 
 ```shell
-curl -L https://git.io/n-install | N_PREFIX=~/util/n bash -s -- -y
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | N_PREFIX=~/util/n bash -s -- -y
 ```
 
 # Installing n
@@ -115,7 +115,7 @@ For other shells, manual updating of the relevant initialization file is require
 ## Installation from GitHub
 
 ```shell
-curl -L https://git.io/n-install | [N_PREFIX=<dir>] bash [-s -- [-y] [<version>...]]
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | [N_PREFIX=<dir>] bash [-s -- [-y] [<version>...]]
 ```
 
 See below for an explanation of the options; `-s --` is required by Bash itself in order to pass options through to the script piped from stdin.
@@ -143,7 +143,7 @@ To bypass that:
 
 ## Manual installation
 
-* Download [this `bash` script](https://git.io/n-install) as `n-install`.
+* Download [this `bash` script](https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install) as `n-install`.
 * Make it executable with `chmod +x`.
 * Move or symlink it to a directory in your `$PATH`.
 * Invoke `n-install` as detailed below.
@@ -228,7 +228,7 @@ DESCRIPTION
     This overrides the default behavior of auto-selecting binaries that match
     the current system.
 
-  For more information, see https://git.io/n-install-repo
+  For more information, see https://github.com/mklement0/n-install
 
 PREREQUISITES
   bash ... to run this script and n itself.

--- a/bin/n-install
+++ b/bin/n-install
@@ -12,14 +12,14 @@ kMIN_BASH_VERSION='3.2'  # due to use of =~, we require at least 3.2
 
 ##### IMPORTANT: These names must, at least in part, be kept in sync with their counterparts in 'n-update' and 'n-uninstall'.
 kINSTALLER_NAME=n-install  # This script's name; note that since we'll typically be running via curl directly from GitHub, using $(basename "$BASH_SOURCE") to determine the name is not an option.
-#  Note: The actual *installation* URL is http://git.io/n-install which redirects to https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install
-kTHIS_REPO_URL='https://git.io/n-install-repo' # This script's source repository - SHORT, git.io-based form.
+#  Note: The actual *installation* URL is https://git.io/n-install which redirects to https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install
+kTHIS_REPO_URL='https://github.com/mklement0/n-install' # This script's source repository - SHORT, git.io-based form.
 kTHIS_REPO_URL_LONG='https://github.com/mklement0/n-install' # This script's source repository in LONG form - needed for deriving raw.githubusercontent.com URLs from it.
 kPREFIX_DIR=${N_PREFIX:-$HOME/n} # The target prefix directory, inside which both a dir. for n itself and the active node version's dirs. will be located.
 ## For updating the relevant shell initialization file: The string that identifies the line added by us.
 ## !! Now that this project has been published, we HARD-CODE this ID string to ensure that old installations are found.
 ## !! For instance, we've changed from http:// to https:// URLs later, but the ID string must continue to use http:// to avoid breaking later uninstalls / reinstalls. 
-kINIT_FILE_LINE_ID=" # Added by n-install (see http://git.io/n-install-repo)."
+kINIT_FILE_LINE_ID=" # Added by n-install (see https://github.com/mklement0/n-install)."
 kREGEX_CONFLICTING_LINE='^[^#]*\bN_PREFIX=' # Regex that identifies relevant existing lines.
 ##### 
 
@@ -52,8 +52,8 @@ kHELPER_SCRIPT_URLS=(
   # !! DO NOT MODIFY THE *FORMAT* OF THIS ARRAY LITERAL - `util/update-checksums`
   # !! and a test rely on it.
 kSHA256_SUMS=(
-  "6fbb9163e08476fe1e3960418a70aece30c6a92de17558f58ea99a24815deb1c  $kUPDATE_SCRIPT"
-  "2a2c4bd2a79bf9510b4472bc0d3d7534e2e808d971565dda694d4ac3c63a92ac  $kUNINSTALL_SCRIPT"
+  "e17b37f2f2025507d792a5ef7c8f06ffe4c53cd02e581baa1bf3c5c14a0c9a0a  $kUPDATE_SCRIPT"
+  "7dc18714039b038f6fcd0b2e6ca432c3c563e521aefcc3e9f4569e93709dd9ab  $kUNINSTALL_SCRIPT"
 )
 ##
 
@@ -304,11 +304,11 @@ getShellInitFileLine() {
     # $N_PREFIX/bin is in the $PATH, followed by the identifying comment.
     # E.g.:
     #   POSIX-compatible shells:
-    #      export N_PREFIX="$HOME/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see http://git.io/n-install-repo).
+    #      export N_PREFIX="$HOME/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see https://github.com/mklement0/n-install).
     #   fish:
-    #      set -x N_PREFIX "$HOME/n"; contains $N_PREFIX $PATH; or set -a PATH $N_PREFIX # Added by n-install (see http://git.io/n-install-repo).
+    #      set -x N_PREFIX "$HOME/n"; contains $N_PREFIX $PATH; or set -a PATH $N_PREFIX # Added by n-install (see https://github.com/mklement0/n-install).
     #   pwsh (PowerShell):
-    #      $env:N_PREFIX="$HOME/n"; if ($env:PATH -split ":" -notcontains "$env:N_PREFIX/bin") { $env:PATH += ":$env:N_PREFIX/bin" } # Added by n-install (see http://git.io/n-install-repo).
+    #      $env:N_PREFIX="$HOME/n"; if ($env:PATH -split ":" -notcontains "$env:N_PREFIX/bin") { $env:PATH += ":$env:N_PREFIX/bin" } # Added by n-install (see https://github.com/mklement0/n-install).
 
     # IMPORTANT:
     #   To facilitate language-neutral, regex-based extracton of the $N_PREFIX value in in `n-uninstall`:
@@ -491,7 +491,7 @@ unset CDPATH  # to prevent unpredictable `cd` behavior
 [[ -t 1 ]] || kNO_COLOR=1 # turn off colored output if stdout is not connected to a terminal
 
 # Output version number and exit, if requested. Note that the `ver='...'` statement is automatically updated by `make version VER=<newVer>` - DO keep the 'v' prefix in the variable _definition_.
-[[ $1 == '--version' ]] && { ver='v0.6.1'; echo "$kTHIS_NAME ${ver#v}"$'\nFor license information and more, visit https://git.io/n-install-repo'; exit 0; }
+[[ $1 == '--version' ]] && { ver='v0.6.1'; echo "$kTHIS_NAME ${ver#v}"$'\nFor license information and more, visit https://github.com/mklement0/n-install'; exit 0; }
 
 # !! AS OF n 1.3.0, n ITSELF ONLY WORKS WITH curl, NOT ALSO WITH wget.
 # !! Once n also supports wget, mention wget as an alternative in the help text.

--- a/bin/n-uninstall
+++ b/bin/n-uninstall
@@ -6,12 +6,12 @@
 
 ##### IMPORTANT: These names must be kept in sync with the master copies in 'n-install'.
 kINSTALLER_NAME='n-install' # The name of the script that installed n.
-kTHIS_REPO_URL='https://git.io/n-install-repo' # This script's source repository.
+kTHIS_REPO_URL='https://github.com/mklement0/n-install' # This script's source repository.
 kPREFIX_DIR=${N_PREFIX:-$HOME/n} # The target prefix directory, inside which both a dir. for n itself and the active node version's dirs. will be located.
 ## For updating the relevant shell initialization file: The string that identifies the line added by us.
 ## !! Now that this project has been published, we HARD-CODE this ID string to ensure that old installations are found.
 ## !! For instance, we've changed from http:// to https:// URLs later, but the ID string must continue to use http:// to avoid breaking later uninstalls / reinstalls. 
-kINIT_FILE_LINE_ID=" # Added by n-install (see http://git.io/n-install-repo)."
+kINIT_FILE_LINE_ID=" # Added by n-install (see https://github.com/mklement0/n-install)."
 ##### 
 
 kTHIS_NAME=$(basename "$0")
@@ -237,7 +237,7 @@ unset CDPATH  # to prevent unpredictable `cd` behavior
 [[ -t 1 ]] || kNO_COLOR=1 # turn off colored output if stdout is not connected to a terminal
 
 # Output version number and exit, if requested. Note that the `ver='...'` statement is automatically updated by `make version VER=<newVer>` - DO keep the 'v' prefix in the variable _definition_.
-[ "$1" = '--version' ] && { ver='v0.6.1'; echo "$kTHIS_NAME ${ver#v}"$'\nFor license information and more, visit https://git.io/n-install-repo'; exit 0; }
+[ "$1" = '--version' ] && { ver='v0.6.1'; echo "$kTHIS_NAME ${ver#v}"$'\nFor license information and more, visit https://github.com/mklement0/n-install'; exit 0; }
 
 # Command-line help.
 if [ "$1" = '--help' ] || [ "$1" = '-h' ]; then

--- a/bin/n-update
+++ b/bin/n-update
@@ -8,7 +8,7 @@ kTHIS_NAME=$(basename "$0")
 
 ##### IMPORTANT: These names must be kept in sync with the master copies in 'n-install'.
 kINSTALLER_NAME=n-install  # The installer script's name.
-kTHIS_REPO_URL='https://git.io/n-install-repo' # This script's source repository.
+kTHIS_REPO_URL='https://github.com/mklement0/n-install' # This script's source repository.
 #####
 
 # 
@@ -124,7 +124,7 @@ unset CDPATH  # to prevent unpredictable `cd` behavior
 [[ -t 1 ]] || kNO_COLOR=1 # turn off colored output if stdout is not connected to a terminal
 
 # Output version number and exit, if requested. Note that the `ver='...'` statement is automatically updated by `make version VER=<newVer>` - DO keep the 'v' prefix in the variable _definition_.
-[ "$1" = '--version' ] && { ver='v0.6.1'; echo "$kTHIS_NAME ${ver#v}"$'\nFor license information and more, visit https://git.io/n-install-repo'; exit 0; }
+[ "$1" = '--version' ] && { ver='v0.6.1'; echo "$kTHIS_NAME ${ver#v}"$'\nFor license information and more, visit https://github.com/mklement0/n-install'; exit 0; }
 
 # Command-line help.
 if [ "$1" = '--help' ] || [ "$1" = '-h' ]; then

--- a/test/.fixtures/shellInitFile-multipleOwnEntries
+++ b/test/.fixtures/shellInitFile-multipleOwnEntries
@@ -1,8 +1,8 @@
 
 # Multiple OWN N_PREFIX= entries.
 
-export N_PREFIX="$DUMMY1/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see http://git.io/n-install-repo).
+export N_PREFIX="$DUMMY1/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see https://github.com/mklement0/n-install).
 
-export N_PREFIX="$DUMMY2/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see http://git.io/n-install-repo).
+export N_PREFIX="$DUMMY2/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see https://github.com/mklement0/n-install).
 
 # original last line

--- a/test/.fixtures/shellInitFile-ownEntry
+++ b/test/.fixtures/shellInitFile-ownEntry
@@ -1,6 +1,6 @@
 
 # Own export N_PREFIX entry.
 
-export N_PREFIX="$DUMMY/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see http://git.io/n-install-repo).
+export N_PREFIX="$DUMMY/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"  # Added by n-install (see https://github.com/mklement0/n-install).
 
 # original last line

--- a/test/6 Modify shell initialization files
+++ b/test/6 Modify shell initialization files
@@ -30,7 +30,7 @@ cleanUp() {
 
 #### !! Must be kept in sync with master copies in 'n-install'.
 kINSTALLER_NAME='n-install' # The name of the script that installed n.
-kTHIS_REPO_URL='http://git.io/n-install-repo' # This script's source repository.
+kTHIS_REPO_URL='https://github.com/mklement0/n-install' # This script's source repository.
 kINIT_FILE_LINE_ID=" # Added by $kINSTALLER_NAME (see $kTHIS_REPO_URL)." # The string that identifies the line added by us.
 #### 
 

--- a/test/7 Do not modify shell initialization files, if requested
+++ b/test/7 Do not modify shell initialization files, if requested
@@ -31,7 +31,7 @@ cleanUp() {
 
 #### !! Must be kept in sync with master copies in 'n-install'.
 kINSTALLER_NAME='n-install' # The name of the script that installed n.
-kTHIS_REPO_URL='http://git.io/n-install-repo' # This script's source repository.
+kTHIS_REPO_URL='https://github.com/mklement0/n-install' # This script's source repository.
 kINIT_FILE_LINE_ID=" # Added by $kINSTALLER_NAME (see $kTHIS_REPO_URL)." # The string that identifies the line added by us.
 #### 
 

--- a/test/8 Run successful and failed installations and updates
+++ b/test/8 Run successful and failed installations and updates
@@ -33,7 +33,7 @@ runUpdate() {
 kTHIS_REPO_URL_LONG='https://github.com/mklement0/n-install' # This script's source repository in LONG form - needed for deriving raw.githubusercontent.com URLs from it.
 #### 
 # Derive the URL and use the *master* branch (not the 'stable' label), so as to use the most recent code in prepraration for a new release.
-# !! By contrast, https://git.io/n-install points to https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install i.e. the *stable* label.
+# !! By contrast, https://git.io/n-install points to  i.e. the *stable* label.
 url="${kTHIS_REPO_URL_LONG/\/\/github.com\////raw.githubusercontent.com/}/master/bin/n-install"
 
 # ----------- INSTALLATION

--- a/test/9 Run successful and failed uninstallations
+++ b/test/9 Run successful and failed uninstallations
@@ -23,7 +23,7 @@ runUninstall() {
 #### !! Must be kept in sync with master copies in 'n-install'.
 kINSTALLER_NAME='n-install' # The name of the script that installed n.
 #  Note: The actual *installation* URL is http://git.io/n-install which redirects to https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install
-kTHIS_REPO_URL='http://git.io/n-install-repo' # This script's source repository - SHORT, git.io-based form.
+kTHIS_REPO_URL='https://github.com/mklement0/n-install' # This script's source repository - SHORT, git.io-based form.
 kTHIS_REPO_URL_LONG='https://github.com/mklement0/n-install' # This script's source repository in LONG form - needed for deriving raw.githubusercontent.com URLs from it.
 kINIT_FILE_LINE_ID=" # Added by $kINSTALLER_NAME (see $kTHIS_REPO_URL)." # The string that identifies the line added by us.
 #### 


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/